### PR TITLE
Update appium-gulp-plugins

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "appium"
+  "extends": "appium",
+  "rules": {
+    "require-await": 0
+  }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "8"
-  - "6"
+  - "10"
 sudo: false
 script:
   - _FORCE_LOGS=1 npm test

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const DEFAULT_PORT = 4774;
 async function main () {
   let port = yargs.argv.port || DEFAULT_PORT;
   let host = yargs.argv.host || DEFAULT_HOST;
-  return startServer(port, host);
+  return await startServer(port, host);
 }
 
 if (require.main === module) {
@@ -20,4 +20,3 @@ if (require.main === module) {
 }
 
 export { FakeDriver, startServer };
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@ import { FakeDriver } from './driver';
 async function startServer (port, host) {
   let d = new FakeDriver();
   let router = routeConfiguringFunction(d);
-  let server = baseServer(router, port, host);
+  let server = await baseServer(router, port, host);
   log.info(`FakeDriver server listening on http://${host}:${port}`);
   return server;
 }

--- a/package.json
+++ b/package.json
@@ -24,11 +24,17 @@
   "directories": {
     "lib": "lib"
   },
+  "files": [
+    "index.js",
+    "lib",
+    "build/index.js",
+    "build/lib"
+  ],
   "dependencies": {
+    "@babel/runtime": "^7.0.0",
     "appium-base-driver": "^3.0.0",
     "appium-support": "^2.11.1",
     "asyncbox": "^2.3.2",
-    "babel-runtime": "=5.8.24",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",
     "source-map-support": "^0.5.5",
@@ -39,7 +45,7 @@
   "scripts": {
     "build": "gulp transpile",
     "mocha": "mocha",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
@@ -49,32 +55,21 @@
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install"
   },
   "devDependencies": {
-    "appium-gulp-plugins": "^2.2.0",
-    "babel-eslint": "^7.1.1",
+    "ajv": "^6.5.3",
+    "appium-gulp-plugins": "3.1.0",
+    "babel-eslint": "^10.0.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
-    "eslint": "^3.10.2",
-    "eslint-config-appium": "^2.0.1",
-    "eslint-plugin-babel": "^3.3.0",
+    "eslint": "^5.2.0",
+    "eslint-config-appium": "^3.1.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-mocha": "^4.7.0",
-    "eslint-plugin-promise": "^3.3.1",
-    "gulp": "^3.8.11",
+    "eslint-plugin-mocha": "^5.0.0",
+    "eslint-plugin-promise": "^4.0.0",
+    "gulp": "^4.0.0",
     "request-promise": "^4.2.2",
-    "sinon": "^6.1.4",
     "wd": "^1.5.0"
   },
   "greenkeeper": {
-    "ignore": [
-      "babel-eslint",
-      "babel-preset-env",
-      "eslint",
-      "eslint-plugin-babel",
-      "eslint-plugin-import",
-      "eslint-plugin-mocha",
-      "eslint-plugin-promise",
-      "gulp",
-      "babel-runtime"
-    ]
+    "ignore": []
   }
 }

--- a/test/alert-tests.js
+++ b/test/alert-tests.js
@@ -28,14 +28,14 @@ function alertTests () {
       await driver.elementById("nav").click()
               .should.eventually.be.rejectedWith(/26/);
     });
-    it.skip('should accept an alert', async function () {
+    it.skip('should accept an alert', function () {
       driver
         .acceptAlert()
         .elementById("nav")
         .click()
         .nodeify();
     });
-    it.skip('should not set the text of the wrong kind of alert', async function () {
+    it.skip('should not set the text of the wrong kind of alert', function () {
       driver
         .elementById("AlertButton2")
         .click()
@@ -45,7 +45,7 @@ function alertTests () {
           .should.be.rejectedWith(/12/)
         .nodeify();
     });
-    it.skip('should dismiss an alert', async function () {
+    it.skip('should dismiss an alert', function () {
       driver
         .acceptAlert()
         .elementById("nav")

--- a/test/context-tests.js
+++ b/test/context-tests.js
@@ -1,7 +1,7 @@
 import { initSession, deleteSession, DEFAULT_CAPS } from './helpers';
 
 function contextTests () {
-  describe('contexts, webviews, frames', async function () {
+  describe('contexts, webviews, frames', function () {
     let driver;
     before (async function () {
       driver = await initSession(DEFAULT_CAPS);

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -28,7 +28,7 @@ describe('FakeDriver - via HTTP', function () {
       server = await startServer(TEST_PORT, TEST_HOST);
     }
   });
-  after(async function () {
+  after(function () {
     if (server) {
       server.close();
     }


### PR DESCRIPTION
This PR does two main things:
1. Updates `eslint-config-appium` and fixes any linting errors.
1. Updated `appium-gulp-plugins` and moves to Babel 7 and Gulp 4.

See https://github.com/appium/appium-gulp-plugins/pull/35 for more details.